### PR TITLE
flickr tags

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -1,52 +1,118 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-us">
-  <head>
+<head>
     <title>Flickr API in jQuery</title>
-	  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-	  <style type="text/css">
-	    body { background: #eee; font-family: monaco, 'courier new', helvetica, sans-serif; }
-	    #container { width: 900px; margin: 50px auto; background: #fff; padding: 25px; border: 1px solid #ccc; }
-	    h1 { color: #eee; font-size: 12px; margin-bottom: 10px; font-weight: normal; background: #111; padding: 7px; }
-	    h1 span { color: #999; }
-	    a img { border: 0; margin: 0; }
-	    div { margin-bottom: 35px; }
-	    ul { list-style-type: none; }
-	    ul li { display: inline; }
-	  </style>
-	  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js" type="text/javascript"></script>
-	  <script src="jquery.flickr.js" type="text/javascript"></script>
-	  <script type="text/javascript">
-	    $(document).ready(function() {
-	      var config = {
-	        api_key: 'YOUR API KEY',
-	        link_to_size: 'm'
-	      }	      
-	          
-	      $('#recent').flickr(config).photosGetRecent({per_page: 10})
-	      $('#contacts').flickr(config).photosGetContactsPublicPhotos({user_id: '95448703@N00', count: 10})
-	      $('#search').flickr(config).photosSearch({user_id: '95448703@N00', per_page: 10})
-	      $('#portfolio').flickr(config).photosSearch({user_id: '95448703@N00', per_page: 10, tags: 'portfolio'})
-	      $('#photoset').flickr(config).photosetsGetPhotos({photoset_id: '72157600185772527', per_page: 10})
-	    })
-	  </script>
-  </head>
-  <body>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <style type="text/css">
+        body {
+            background: #eee;
+            font-family: monaco, 'courier new' , helvetica, sans-serif;
+        }
+        #container {
+            width: 900px;
+            margin: 50px auto;
+            background: #fff;
+            padding: 25px;
+            border: 1px solid #ccc;
+        }
+        h1 {
+            color: #eee;
+            font-size: 12px;
+            margin-bottom: 10px;
+            font-weight: normal;
+            background: #111;
+            padding: 7px;
+        }
+        h1 span {
+            color: #999;
+        }
+        a img {
+            border: 0;
+            margin: 0;
+        }
+        div {
+            margin-bottom: 35px;
+        }
+        div#tags {
+            margin-left: 10px; 
+            float: right;
+        }
+        div#tags select {
+            border: thin black solid;
+        }
+        div#photosByTag {
+            min-height: 40px;
+        }
+        ul {
+            list-style-type: none;
+        }
+        ul li {
+            display: inline;
+        }
+    </style>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.js" type="text/javascript"></script>
+    <script src="jquery.flickr.js" type="text/javascript"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            var config = {
+                api_key: '6923603b2d89e67731a25b51962c8f19',
+                link_to_size: 'm'
+            }
+
+            $('#recent').flickr(config).photosGetRecent({ per_page: 100 });
+            $('#contacts').flickr(config).photosGetContactsPublicPhotos({ user_id: '95448703@N00', count: 10 });
+            $('#search').flickr(config).photosSearch({ user_id: '95448703@N00', per_page: 20 });
+            $('#portfolio').flickr(config).photosSearch({ user_id: '95448703@N00', per_page: 10, tags: 'portfolio' });
+            $('#photoset').flickr(config).photosetsGetPhotos({ photoset_id: '72157600185772527', per_page: 10 });
+
+            var getPhotosOnChange = function (event) {
+                var selectedTags = $.map(this.options, function (option) {
+                    if (option.selected) { return [option.value]; }
+                }).join(",");
+                $('#photosByTag').empty().flickr(config).photosSearch({ user_id: '95448703@N00', per_page: 16, tags: selectedTags });
+            }
+
+            $('#tags').flickr(config).tagSelect(
+                { user_id: '95448703@N00' },
+                {
+                    multiple: true,
+                    size: 5,
+                    prompt: 'Select tags...',
+                    onchange: getPhotosOnChange
+                }
+            );
+        })
+    </script>
+</head>
+<body>
     <div id="container">
-      <h1>photosGetRecent()</h1>
-      <div id="recent"></div>
-      
-      <h1>photosGetContactsPublicPhotos(<span>{user_id: '95448703@N00', count: 10}</span>)</h1>
-      <div id="contacts"></div>
-      
-      <h1>photosSearch(<span>{user_id: '95448703@N00', per_page: 10}</span>)</h1>
-      <div id="search"></div>
-      
-      <h1>photosSearch(<span>{user_id: '95448703@N00', per_page: 10, tags: 'portfolio'}</span>)</h1>
-      <div id="portfolio"></div>
-      
-      <h1>photosetsGetPhotos(<span>{photoset_id: '72157600185772527', per_page: 10}</span>)</h1>
-      <div id="photoset"></div>
+        <h1>
+            photosGetRecent()</h1>
+        <div id="recent">
+        </div>
+        <h1>
+            photosGetContactsPublicPhotos(<span>{user_id: '95448703@N00', count: 10}</span>)</h1>
+        <div id="contacts">
+        </div>
+        <h1>
+            photosSearch(<span>{user_id: '95448703@N00', per_page: 10}</span>)</h1>
+        <div id="search">
+        </div>
+        <h1>
+            photosSearch(<span>{user_id: '95448703@N00', per_page: 10, tags: 'portfolio'}</span>)</h1>
+        <div id="portfolio">
+        </div>
+        <h1>
+            photosetsGetPhotos(<span>{photoset_id: '72157600185772527', per_page: 10}</span>)</h1>
+        <div id="photoset">
+        </div>
+        <h1>
+            tagSelect(<span>{user_id: '95448703@N00'},{multiple: true, size: 5, prompt: 'Select one...', onchange: getPhotosByTag }}</span>)</h1>
+        <div id="tags">
+        </div>
+        <div id="photosByTag">
+        </div>
     </div>
-  </body>
+</body>
 </html>

--- a/jquery.flickr.js
+++ b/jquery.flickr.js
@@ -3,6 +3,11 @@
  * version: 1.0 (02/23/2009)
  * written for jQuery 1.3.2
  * by Ryan Heath (http://rpheath.com)
+ *
+ * Changes: 
+ *  - Added tagSelect method to get the list of tags
+ *    in a flickr account which can be used to filter
+ *    the displayed images. Dan Smith 05/23/2011.
  *****************************************/
 (function($) {
   // core extensions
@@ -15,7 +20,7 @@
       return true
     }
   })
-  
+
   // base flickr object
   $.flickr = {
     // the actual request url
@@ -31,28 +36,28 @@
         case 't' : return '_t' // thumbnail
         case 's' : return '_m' // small
         case 'm' : return ''   // medium
-        default  : return ''   // medium
+        default: return ''   // medium
       }
     },
     // determines what to do with the links
     linkTag: function(text, photo, href) {
-      if (href === undefined) href = ['http://www.flickr.com/photos', photo.owner, photo.id].join('/')      
+      if (href === undefined) href = ['http://www.flickr.com/photos', photo.owner, photo.id].join('/')
       return '<a href="' + href + '" title="' + photo.title + '">' + text + '</a>'
     }
   }
-  
+
   // helper methods for thumbnails
   $.flickr.thumbnail = {
     src: function(photo, size) {
       if (size === undefined) size = $.flickr.translate($.flickr.settings.thumbnail_size)
-      return 'http://farm' + photo.farm + '.static.flickr.com/' + photo.server + 
+      return 'http://farm' + photo.farm + '.static.flickr.com/' + photo.server +
         '/' + photo.id + '_' + photo.secret + size + '.jpg'
     },
     imageTag: function(image) {
       return '<img src="' + image.src + '" alt="' + image.alt + '" />'
     }
   }
-  
+
   // accepts a series of photos and constructs
   // the thumbnails that link back to Flickr
   $.flickr.thumbnail.process = function(photos) {
@@ -63,22 +68,22 @@
       image.alt = photo.title
 
       var size = $.flickr.settings.link_to_size
-      if (size != undefined && size.match(/sq|t|s|m|o/)) 
+      if (size != undefined && size.match(/sq|t|s|m|o/))
         href = $.flickr.thumbnail.src(photo, $.flickr.translate(size))
-      
+
       html = $.flickr.linkTag($.flickr.thumbnail.imageTag(image), photo, href)
-        
+
       return ['<li>' + html + '</li>']
     }).join("\n")
-    
+
     return $('<ul class="flickr"></ul>').append(thumbnails)
   }
-  
+
   // handles requesting and thumbnailing photos
   $.flickr.photos = function(method, options) {
     var options = $.extend($.flickr.settings, options || {}),
         elements = $.flickr.self, photos
-    
+
     return elements.each(function() {
       $.getJSON($.flickr.url(method, options), function(data) {
         photos = (data.photos === undefined ? data.photoset : data.photos)
@@ -86,7 +91,44 @@
       })
     })
   }
-  
+
+  // handles requesting list of tags
+  $.flickr.tags = function(method, options, select) {
+    var options = $.extend($.flickr.settings, options || {}),
+  		  elements = $.flickr.self, tags
+
+    return elements.each(function() {
+      $.getJSON($.flickr.url(method, options), function(data) {
+        var list = $.flickr.tags.selectList(data.who.tags, select);
+        elements.append(list);
+      })
+    })
+  }
+
+  // converts tags into select list. parameters:
+  //  multiple: can select multiple items in list (bool).
+  //  size: length of displayed list box, set to 0 to create a drop down list (integer).
+  //  prompt: adds a text prompt to the top of the list (e.g. "Please select...") (string).
+  //  onchange: callback to handle the select list's change event (function).
+  $.flickr.tags.selectList = function(tags, options) {
+    // what if there are no tags?
+    var optionList = $.map(tags.tag, function(tag) {
+      return ['<option value="' + tag._content + '">' + tag._content + '</option>']
+    }).join("\n")
+
+    var selectList = $('<select class="flickr"></select>');
+    if (options.multiple === true)
+      selectList.attr('multiple', 'multiple');
+    if (options.size !== undefined && options.size > 0)
+      selectList.attr('size', options.size);
+    if (options.prompt !== undefined && options.prompt != '')
+      selectList.append('<option value="" selected="selected">' + options.prompt + '</option>');
+    if (typeof(options.onchange) === 'function')
+      selectList.change(options.onchange);
+
+    return selectList.append(optionList)
+  }
+
   // namespace to hold available API methods
   // note: options available to each method match that of Flickr's docs
   $.flickr.methods = {
@@ -105,19 +147,24 @@
     // http://www.flickr.com/services/api/flickr.photosets.getPhotos.html
     photosetsGetPhotos: function(options) {
       $.flickr.photos('flickr.photosets.getPhotos', options)
+    },
+    // http://www.flickr.com/services/api/flickr.tags.getListUser.html
+    // select parameter; {multiple: true, size: 4, prompt: 'Select one...', onchange: getPhotosByTag }
+    tagSelect: function(options, select) {
+      $.flickr.tags('flickr.tags.getListUser', options, select)
     }
   }
-  
+
   // the plugin
   $.fn.flickr = function(options) {
     $.flickr.self = $(this)
-    
+
     // base configuration
     $.flickr.settings = $.extend({
       api_key: 'YOUR API KEY',
       thumbnail_size: 'sq'
     }, options || {})
-    
+
     return $.flickr.methods
   }
 })(jQuery);


### PR DESCRIPTION
Added tagSelect method that fetches tags used on the photos and turns it into a select list. The select list can then be used to filter the photos returned from a photoSearch method call.
- Example included in examples.html
